### PR TITLE
start command improvements

### DIFF
--- a/nginx/conf.liquid
+++ b/nginx/conf.liquid
@@ -1,0 +1,1 @@
+# conf.liquid

--- a/nginx/main.conf.liquid
+++ b/nginx/main.conf.liquid
@@ -1,4 +1,5 @@
-{% include "env.conf" %}
+{% include "conf.liquid" %}
+
 
 daemon {{ daemon }};
 master_process {{ master_process }};

--- a/src/apicast-cli/cli/start.lua
+++ b/src/apicast-cli/cli/start.lua
@@ -54,11 +54,24 @@ local function call(m, parser)
   return start_cmd
 end
 
-local _M = { }
+local _M = { openresty = { 'openresty-debug', 'openresty', 'nginx' } }
 local mt = { __call = call }
 
 
+local function pick_openesty(candidates)
+  for i=1, #candidates do
+    local ok = os.execute(('%s -V 2>/dev/null'):format(candidates[i]))
+
+    if ok then
+      return candidates[i]
+    end
+  end
+
+  error("could not find openresty executable")
+end
+
 function _M.start(args)
+  local openresty = pick_openesty(_M.openresty)
   local path = args.path
   local attributes = lfs.attributes(path)
   local context = configuration:load()
@@ -81,7 +94,7 @@ function _M.start(args)
         table.insert(arg, args.debug and '-T' or '-t')
       end
 
-      exec('openresty', arg)
+      exec(openresty, arg)
     else
       say('path %s is not a file but a %s', path, mode)
       os.exit(1)

--- a/src/apicast-cli/cli/start.lua
+++ b/src/apicast-cli/cli/start.lua
@@ -40,16 +40,18 @@ function Liquid.FileSystem.get(location)
 end
 
 local function call(m, parser)
-  local create_cmd = parser:command("s start", "Start Nginx")
+  local start_cmd = parser:command("s start", "Start Nginx")
   :action(m.start)
 
-  create_cmd:usage(colors("%{bright red}Usage: apicast-cli start [PATH]"))
-  create_cmd:argument("path", "The name of your application.", 'nginx/main.conf.liquid')
+  start_cmd:usage(colors("%{bright red}Usage: apicast-cli start [PATH]"))
+  start_cmd:argument("path", "The name of your application.", 'nginx/main.conf.liquid')
+  start_cmd:flag("-t --test", "Test the nginx config")
+  start_cmd:flag("-d --debug", "Debug mode. Prints more information.")
   -- create_cmd:argument("path", "The path to where you wish your app to be created."):default(".")
-  create_cmd:epilog(colors([[
+  start_cmd:epilog(colors([[
       Example: %{bright red} apicast-cli start path/to/template.liquid%{reset}
         This will create start nginx using tempalte path/to/template.liquid.]]))
-  return create_cmd
+  return start_cmd
 end
 
 local _M = { }
@@ -73,7 +75,13 @@ function _M.start(args)
 
       pl.file.write(tmp, config)
 
-      exec('openresty', '-c', tmp)
+      local arg = { '-c', tmp }
+
+      if args.test then
+        table.insert(arg, args.debug and '-T' or '-t')
+      end
+
+      exec('openresty', arg)
     else
       say('path %s is not a file but a %s', path, mode)
       os.exit(1)

--- a/src/apicast-cli/cli/start.lua
+++ b/src/apicast-cli/cli/start.lua
@@ -1,5 +1,4 @@
 local colors = require "ansicolors"
-local Liquid = require 'liquid'
 local configuration = require 'apicast-cli.configuration'
 local exec = require('apicast-cli.utils.exec')
 
@@ -9,35 +8,6 @@ local pl = {
 }
 
 local Template = require('apicast-cli.template')
-
-local lfs = require('lfs')
-
-local function say(format, ...)
-  return print(string.format(format, ...))
-end
-
-local function read(path)
-  local attributes = lfs.attributes(path)
-
-  if attributes and attributes.mode == 'file' then
-    local file, err = io.open(path, 'r')
-
-    if file then
-      local content = file:read('*a')
-
-      file:close()
-      return content
-    else
-      return nil, err
-    end
-  else
-    return nil, 'not a file'
-  end
-end
-
-function Liquid.FileSystem.get(location)
-  return read(location) or ''
-end
 
 local _M = {
   openresty = { 'openresty-debug', 'openresty', 'nginx' },
@@ -79,43 +49,30 @@ end
 
 function _M.start(args)
   local openresty = pick_openesty(_M.openresty)
-  local path = args.path
-  local attributes = lfs.attributes(path)
+  local dir = pl.path.dirname(args.path)
+  local path = pl.path.basename(args.path)
   local context = configuration:load()
-  local template = Template:new(context)
+  local template = Template:new(context, dir, true)
 
-  if attributes then
-    local mode = attributes.mode
+  local config = template:render(path)
 
-    if mode == 'file' then
+  local tmp = pl.path.tmpname()
 
-      local config = template:render(path)
+  pl.file.write(tmp, config)
 
-      local tmp = pl.path.tmpname()
+  local log_level = _M.log_levels[_M.log_level + args.verbose - args.quiet]
+  local log_file = args.log or _M.log_file
+  local global = {
+    ('error_log %s %s'):format(log_file, log_level)
+  }
 
-      pl.file.write(tmp, config)
+  local cmd = { '-c', tmp, '-g', table.concat(global, '; ') .. ';' }
 
-      local log_level = _M.log_levels[_M.log_level + args.verbose - args.quiet]
-      local log_file = args.log or _M.log_file
-      local global = {
-        ('error_log %s %s'):format(log_file, log_level)
-      }
-
-      local cmd = { '-c', tmp, '-g', table.concat(global, '; ') .. ';' }
-
-      if args.test then
-        table.insert(cmd, args.debug and '-T' or '-t')
-      end
-
-      exec(openresty, cmd)
-    else
-      say('path %s is not a file but a %s', path, mode)
-      os.exit(1)
-    end
-  else
-    say('path %s does not exist', path)
-    os.exit(1)
+  if args.test then
+    table.insert(cmd, args.debug and '-T' or '-t')
   end
+
+  exec(openresty, cmd)
 end
 
 return setmetatable(_M, mt)

--- a/src/apicast-cli/configuration.lua
+++ b/src/apicast-cli/configuration.lua
@@ -8,6 +8,7 @@ local _M = {
     master_process = 'off',
     worker_processes = 1,
     daemon = 'off',
+    port = 8080,
   }
 }
 

--- a/src/apicast-cli/template.lua
+++ b/src/apicast-cli/template.lua
@@ -34,12 +34,11 @@ local function noop(...) return ... end
 function _M:new(config, dir, strict)
   local instance = setmetatable({}, { __index = self })
 
-  local assert = strict and assert or noop
-
   instance.root = pl.path.abspath(dir or pl.path.currentdir())
 
+  instance.strict = strict
   instance.filesystem = FileSystem:new(function(path)
-    return assert(instance:read(path))
+    return instance:read(path)
   end)
 
   local fs = LazyFileSystem:new(instance)
@@ -51,8 +50,9 @@ end
 
 function _M:read(template_name)
   local root = self.root
+  local assert = self.strict and assert or noop
 
-  return pl.file.read(pl.path.join(root, template_name))
+  return assert(pl.file.read(pl.path.join(root, template_name)))
 end
 
 

--- a/src/apicast-cli/template.lua
+++ b/src/apicast-cli/template.lua
@@ -29,13 +29,17 @@ function LazyFileSystem:new(template)
   return Lazy:new(filesystem)
 end
 
-function _M:new(config, dir)
+local function noop(...) return ... end
+
+function _M:new(config, dir, strict)
   local instance = setmetatable({}, { __index = self })
+
+  local assert = strict and assert or noop
 
   instance.root = pl.path.abspath(dir or pl.path.currentdir())
 
   instance.filesystem = FileSystem:new(function(path)
-    return instance:read(path)
+    return assert(instance:read(path))
   end)
 
   local fs = LazyFileSystem:new(instance)

--- a/src/apicast-cli/utils/exec.lua
+++ b/src/apicast-cli/utils/exec.lua
@@ -12,10 +12,10 @@ int execvp(const char *file, const char *argv[]);
 
 local string_array_t = typeof("const char *[?]")
 
-local function execvp(filename, ...)
-  local argv = { filename, ... }
-  local cargv = string_array_t(#argv + 1, argv)
-  cargv[#argv] = nil
+local function execvp(filename, args)
+  table.insert(args, 1, filename) -- the command name should be the first arg
+  local cargv = string_array_t(#args + 1, args)
+  cargv[#args] = nil
   C.execvp(filename, cargv)
   error(ffi.string(ffi.C.strerror(ffi.errno())))
 end


### PR DESCRIPTION
* test and print the config
* control log level
* find correct openresty binary
* crash when `{% include %}` missing file
* include files relative to the main template file

closes #1 